### PR TITLE
add link to publiccode.yml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The current mvp, based on the stories on github (https://github.com/codeforameri
 
 ## Technologies Used
 * Github
-* publicode.yml https://github.com/italia/publiccode.yml
+* [publicode.yml](https://github.com/italia/publiccode.yml)
 
 ## Guiding Principles
 * Have an open and accessible process with outreach, documentation, public discussions and transparent decisions

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The current mvp, based on the stories on github (https://github.com/codeforameri
 
 ## Technologies Used
 * Github
+* publicode.yml https://github.com/italia/publiccode.yml
 
 ## Guiding Principles
 * Have an open and accessible process with outreach, documentation, public discussions and transparent decisions


### PR DESCRIPTION
Now that we've settled on publiccode.yml for a data schema, we should link to it prominently so that contributors can find it easily. I put it under **Technologies Used**