### PR TITLE
Include project description when fetching from Github

### DIFF
--- a/crawler/run.js
+++ b/crawler/run.js
@@ -464,6 +464,7 @@ async function loadGithubTopicProjects(repo, topic) {
         const projectData = {
             name: repo.name,
             code_url: repo.html_url,
+            description: repo.description,
             git_url: repo.git_url,
             git_branch: repo.default_branch,
             link_url: repo.homepage || null,

--- a/crawler/run.js
+++ b/crawler/run.js
@@ -377,6 +377,7 @@ async function loadGithubOrgProjects(repo, username) {
         const projectData = {
             name: repo.name,
             code_url: repo.html_url,
+            description: repo.description,
             git_url: repo.git_url,
             git_branch: repo.default_branch,
             link_url: repo.homepage || null,


### PR DESCRIPTION
The homepage is already fetched from the repo metadata, let's also
include the repo's description for presentation by clients. (The
description is already fetched from, and commonly included in, the CSV
project list format.)