### PR TITLE
chore(vscode): match markdown lint to mkdocs behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "markdownlint.config": {
+        "default": true,
+        "MD007": { "indent": 4 }
+    },
+}


### PR DESCRIPTION
mkdocs works best when 4 space indentation is used consistently for lists, as ambiguous cases can arise when embedding advanced content within lists or nested lists that result in things not getting rendered correctly. You'll commonly encounter this when having code blocks or admonitions within list bullets.

See [this rats nest](https://github.com/radude/mdx_truly_sane_lists/issues/6) for example

This PR configures VSCode's markdown linter